### PR TITLE
Jackson-annotations causing classloader conflicts #189 (#190)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation libs.graphql.java;
     implementation libs.graphql.java.extended.scalars;
     implementation libs.rxjava;
-    implementation libs.jackson.annotations;
+    compileOnly libs.jackson.annotations;
 
     testImplementation platform( libs.mockito.core )
     testImplementation libs.junit.jupiter


### PR DESCRIPTION
(cherry picked from commit bdbd9d216fd683c5617681152c25d7cb8d4c49ce)