### PR TITLE
Remove unused Jackson annotations dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation libs.graphql.java;
     implementation libs.graphql.java.extended.scalars;
     implementation libs.rxjava;
-    compileOnly libs.jackson.annotations;
 
     testImplementation platform( libs.mockito.core )
     testImplementation libs.junit.jupiter

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ enonicXpGradle = "4.0.0-A3"
 graphQLJava = "26.0"
 graphQLJavaExtendedScalars = "24.0"
 rxJava = "2.2.21"
-jacksonAnnotations = "2.22"
 
 [libraries]
 
@@ -18,7 +17,6 @@ mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = 
 graphql-java = { module = "com.graphql-java:graphql-java", version.ref = "graphQLJava" }
 graphql-java-extended-scalars = { module = "com.graphql-java:graphql-java-extended-scalars", version.ref = "graphQLJavaExtendedScalars" }
 rxjava = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxJava" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jacksonAnnotations" }
 
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }

--- a/src/main/java/com/enonic/lib/graphql/rx/Publisher.java
+++ b/src/main/java/com/enonic/lib/graphql/rx/Publisher.java
@@ -2,9 +2,6 @@ package com.enonic.lib.graphql.rx;
 
 import org.reactivestreams.Subscriber;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreType;
-
-@JsonIgnoreType
 public class Publisher<T>
 {
     private final org.reactivestreams.Publisher publisher;


### PR DESCRIPTION
## What

Removes the `@JsonIgnoreType` annotation from `rx/Publisher`, its import, the `compileOnly libs.jackson.annotations` build dependency, and the corresponding version-catalog entries.

## Why

This library never serializes through Jackson. The only Jackson usage was `@JsonIgnoreType` on `Publisher`, but the class is never handed to a Jackson `ObjectMapper`:

- `ExecutionResultMapper` implements XP's `MapSerializable` SPI.
- For a subscription result it wraps the reactive-streams `Publisher` and emits it via `gen.rawValue( "data", publisherSerializable )` — pushing the raw Java object straight through to the script layer as an opaque handle.
- The JS side (`graphql-rx.js`) just hands it back to `RxBean` to `.subscribe(...)`.

No `ObjectMapper` is invoked anywhere in this lib, so the annotation has no effect on its own code path and the dependency is dead weight.

## Note

If any downstream consumer (e.g. a portal websocket/SSE endpoint outside this repo) was relying on `@JsonIgnoreType` to keep this pass-through `Publisher` from tripping Jackson's `FAIL_ON_EMPTY_BEANS`, that guard goes away with this change. Flagging in case that path exists — from this repo alone there's no such usage.

## Verification

`grep` confirms no remaining references to `jackson` / `JsonIgnore` / `fasterxml`. Full Gradle compile could not be run in the environment (project targets JDK 25; only JDK 21 available), but the change is purely subtractive and no remaining code references the removed symbols.

https://claude.ai/code/session_01MhHPZESGph4ojGam85WEHc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhHPZESGph4ojGam85WEHc)_