### PR TITLE
Migrate to XP Gradle settings plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'maven-publish'
-    alias( libs.plugins.enonic.defaults )
-    alias( libs.plugins.enonic.xp.base )
+    id 'com.enonic.defaults' version '2.1.7'
+    id 'com.enonic.xp.base'
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,6 @@
 
 junit = "6.1.1"
 mockito = "5.23.0"
-enonicDefaults = "2.1.7"
-enonicXpGradle = "4.1.0"
 graphQLJava = "26.0"
 graphQLJavaExtendedScalars = "24.0"
 
@@ -15,7 +13,3 @@ mockito-core = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
 mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 graphql-java = { module = "com.graphql-java:graphql-java", version.ref = "graphQLJava" }
 graphql-java-extended-scalars = { module = "com.graphql-java:graphql-java-extended-scalars", version.ref = "graphQLJavaExtendedScalars" }
-
-[plugins]
-enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }
-enonic-xp-base = { id = "com.enonic.xp.base", version.ref = "enonicXpGradle" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.1.0'
+}
+
 rootProject.name = projectName


### PR DESCRIPTION
Applies the `com.enonic.xp.settings` plugin in `settings.gradle` to manage the XP Gradle plugin version centrally, matching the convention used across the other XP libraries.

## Changes
- `settings.gradle`: apply `com.enonic.xp.settings` version `4.1.0`
- `build.gradle`: use `id (quote)com.enonic.xp.base(quote)` (version now supplied by the settings plugin) and inline `com.enonic.defaults` version
- `gradle/libs.versions.toml`: drop the `[plugins]` section and the now-unused `enonicXpGradle` / `enonicDefaults` version refs

Verified with `./gradlew build` (compile + tests pass).

Fixes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)