### PR TITLE
Add @enonic-types/lib-graphql types package #200

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push, workflow_dispatch ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             3.x
             master

--- a/build.gradle
+++ b/build.gradle
@@ -47,3 +47,16 @@ test {
 }
 
 check.dependsOn jacocoTestReport
+
+// Assemble the @enonic-types/lib-graphql npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    exclude 'tsconfig.json', 'test/**'
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,274 @@
+// Type definitions for @enonic/lib-graphql
+// Covers three importable modules:
+//   /lib/graphql             — schema builder, scalars, execution
+//   /lib/graphql-connection  — Relay-style connection helper
+//   /lib/graphql-rx          — reactive subscription plumbing
+
+declare module "/lib/graphql" {
+    // ---------------------------------------------------------------------
+    // Opaque type handles
+    // ---------------------------------------------------------------------
+    // Consumers pass these around but do not introspect them. The `_kind`
+    // brand is nominal — TypeScript never observes it at runtime.
+
+    export interface GraphQLType {
+        readonly _kind?: string;
+    }
+
+    export interface GraphQLScalarType extends GraphQLType {
+        readonly _kind?: "Scalar";
+    }
+
+    export interface GraphQLObjectType extends GraphQLType {
+        readonly _kind?: "Object";
+        /** Returns the type's declared `name`. Used by `createConnectionType` to derive edge/connection names. */
+        getName(): string;
+    }
+
+    export interface GraphQLInputObjectType extends GraphQLType {
+        readonly _kind?: "InputObject";
+    }
+
+    export interface GraphQLInterfaceType extends GraphQLType {
+        readonly _kind?: "Interface";
+    }
+
+    export interface GraphQLUnionType extends GraphQLType {
+        readonly _kind?: "Union";
+    }
+
+    export interface GraphQLEnumType extends GraphQLType {
+        readonly _kind?: "Enum";
+    }
+
+    export interface GraphQLTypeReference extends GraphQLType {
+        readonly _kind?: "Reference";
+    }
+
+    /** Opaque schema handle produced by `createSchema` and consumed by `execute`. */
+    export interface GraphQLSchema {
+        readonly _kind?: "Schema";
+    }
+
+    // ---------------------------------------------------------------------
+    // Scalars
+    // ---------------------------------------------------------------------
+
+    export const GraphQLInt: GraphQLScalarType;
+    export const GraphQLFloat: GraphQLScalarType;
+    export const GraphQLString: GraphQLScalarType;
+    export const GraphQLBoolean: GraphQLScalarType;
+    export const GraphQLID: GraphQLScalarType;
+
+    // Extended scalars (>= 1.2.0)
+    export const Date: GraphQLScalarType;
+    export const DateTime: GraphQLScalarType;
+    export const Time: GraphQLScalarType;
+    export const Json: GraphQLScalarType;
+
+    // Custom scalars (>= 2.0.0)
+    export const LocalDateTime: GraphQLScalarType;
+    export const LocalTime: GraphQLScalarType;
+
+    // ---------------------------------------------------------------------
+    // Field / resolver types
+    // ---------------------------------------------------------------------
+
+    /**
+     * Environment passed to every field `resolve` function.
+     * Generic parameters let callers narrow `source`/`args`/`context` where they know the shape;
+     * the defaults reflect what the Java bridge actually guarantees (nothing).
+     */
+    export interface DataFetchingEnvironment<Source = unknown, Args = Record<string, unknown>, Context = unknown> {
+        source: Source;
+        args: Args;
+        context: Context;
+    }
+
+    /**
+     * A field definition in an object/interface type. The `resolve` function is optional;
+     * when absent, the runtime uses graphql-java's `PropertyDataFetcher`, which reads the
+     * matching property off `source`.
+     *
+     * `env.args` is typed as `any` in the default resolver signature so callers can narrow
+     * it to a concrete interface in their own resolver's `env: DataFetchingEnvironment<...>`
+     * annotation without an explicit cast. The runtime never validates arg shape — the
+     * schema does — so this matches actual behavior.
+     */
+    export interface GraphQLFieldConfig<Source = unknown, Context = unknown> {
+        type: GraphQLType;
+        args?: Record<string, GraphQLType>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        resolve?: (env: DataFetchingEnvironment<Source, any, Context>) => unknown;
+    }
+
+    /** Fields for input object types — no `args`, no `resolve`. */
+    export interface GraphQLInputFieldConfig {
+        type: GraphQLType;
+    }
+
+    export type GraphQLFieldMap<Source = unknown, Context = unknown> = Record<
+        string,
+        GraphQLFieldConfig<Source, Context>
+    >;
+
+    export type GraphQLInputFieldMap = Record<string, GraphQLInputFieldConfig>;
+
+    // ---------------------------------------------------------------------
+    // Schema builder parameters
+    // ---------------------------------------------------------------------
+
+    export interface CreateSchemaParams {
+        query: GraphQLObjectType;
+        mutation?: GraphQLObjectType;
+        subscription?: GraphQLObjectType;
+        /** Additional types needed for reference resolution. */
+        dictionary?: GraphQLObjectType[];
+    }
+
+    export interface CreateObjectTypeParams<Source = unknown, Context = unknown> {
+        name: string;
+        description?: string;
+        fields: GraphQLFieldMap<Source, Context>;
+        interfaces?: Array<GraphQLInterfaceType | GraphQLTypeReference>;
+    }
+
+    export interface CreateInputObjectTypeParams {
+        name: string;
+        description?: string;
+        fields: GraphQLInputFieldMap;
+    }
+
+    export interface CreateInterfaceTypeParams<Source = unknown, Context = unknown> {
+        name: string;
+        description?: string;
+        fields: GraphQLFieldMap<Source, Context>;
+        /**
+         * Called at execution time to pick the concrete `GraphQLObjectType` for a runtime value.
+         * Must return an already-defined object type (not a reference).
+         */
+        typeResolver: (source: Source) => GraphQLObjectType;
+    }
+
+    export interface CreateUnionTypeParams<Source = unknown> {
+        name: string;
+        types: Array<GraphQLObjectType | GraphQLTypeReference>;
+        typeResolver: (source: Source) => GraphQLObjectType;
+        description?: string;
+    }
+
+    /**
+     * Enum values can be provided as a `string[]` (name === value) or as a
+     * `Record<string, unknown>` mapping enum-name -> backing value.
+     */
+    export interface CreateEnumTypeParams {
+        name: string;
+        values: string[] | Record<string, unknown>;
+        description?: string;
+    }
+
+    // ---------------------------------------------------------------------
+    // Schema generator
+    // ---------------------------------------------------------------------
+
+    export interface SchemaGenerator {
+        createSchema(params: CreateSchemaParams): GraphQLSchema;
+        createObjectType<Source = unknown, Context = unknown>(
+            params: CreateObjectTypeParams<Source, Context>
+        ): GraphQLObjectType;
+        createInputObjectType(params: CreateInputObjectTypeParams): GraphQLInputObjectType;
+        createInterfaceType<Source = unknown, Context = unknown>(
+            params: CreateInterfaceTypeParams<Source, Context>
+        ): GraphQLInterfaceType;
+        createUnionType<Source = unknown>(params: CreateUnionTypeParams<Source>): GraphQLUnionType;
+        createEnumType(params: CreateEnumTypeParams): GraphQLEnumType;
+        createPageInfoObjectType<Source = unknown, Context = unknown>(
+            params: CreateObjectTypeParams<Source, Context>
+        ): GraphQLObjectType;
+    }
+
+    export function newSchemaGenerator(): SchemaGenerator;
+
+    // ---------------------------------------------------------------------
+    // Type wrappers
+    // ---------------------------------------------------------------------
+
+    /** Wraps a type to indicate a list of that type (`[T]`). */
+    export function list(type: GraphQLType): GraphQLType;
+
+    /** Wraps a type to indicate a non-null occurrence (`T!`). */
+    export function nonNull(type: GraphQLType): GraphQLType;
+
+    /** Placeholder for a type identified by name — resolved when the schema is assembled. */
+    export function reference(typeKey: string): GraphQLTypeReference;
+
+    // ---------------------------------------------------------------------
+    // Execution
+    // ---------------------------------------------------------------------
+
+    /** GraphQL execution result — shape mirrors the graphql-java `ExecutionResult` structure. */
+    export interface ExecutionResult<Data = unknown> {
+        data?: Data;
+        errors?: unknown[];
+        extensions?: Record<string, unknown>;
+    }
+
+    /**
+     * Runs a query against a schema. `variables` and `context` are optional at runtime;
+     * omitted values are passed through to graphql-java as null.
+     */
+    export function execute<Data = unknown>(
+        schema: GraphQLSchema,
+        query: string,
+        variables?: Record<string, unknown>,
+        context?: unknown
+    ): ExecutionResult<Data>;
+}
+
+declare module "/lib/graphql-connection" {
+    import type { GraphQLObjectType, SchemaGenerator } from "/lib/graphql";
+
+    /**
+     * Builds a Relay-style connection object type wrapping the given node type.
+     * The connection is generated with `<NodeType>Connection` / `<NodeType>Edge` names
+     * derived from `type.getName()`.
+     */
+    export function createConnectionType(
+        schemaGenerator: SchemaGenerator,
+        type: GraphQLObjectType
+    ): GraphQLObjectType;
+
+    /** Base64-encodes an opaque cursor value. */
+    export function encodeCursor(value: string | number): string;
+
+    /** Reverse of `encodeCursor`. */
+    export function decodeCursor(value: string): string;
+}
+
+declare module "/lib/graphql-rx" {
+    /**
+     * Opaque handle backed by a graphql-java `PublishProcessor`. Push values via `onNext`,
+     * close via `onComplete`, or fail via `onError`. Return one from a subscription resolver.
+     */
+    export interface PublishProcessor<T = unknown> {
+        readonly _kind?: "PublishProcessor";
+        onNext(value: T): void;
+        onError(error: unknown): void;
+        onComplete(): void;
+    }
+
+    /** Opaque handle backed by a graphql-java `Subscriber`. Wired to receive push updates. */
+    export interface Subscriber<T = unknown> {
+        readonly _kind?: "Subscriber";
+    }
+
+    export interface CreateSubscriberParams<T = unknown> {
+        onNext?: (value: T) => void;
+    }
+
+    export function createPublishProcessor<T = unknown>(): PublishProcessor<T>;
+
+    export function createSubscriber<T = unknown>(params: CreateSubscriberParams<T>): Subscriber<T>;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-graphql",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP GraphQL library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-graphql",
+    "graphql",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-graphql#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-graphql.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-graphql/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}

--- a/types/test/typecheck.ts
+++ b/types/test/typecheck.ts
@@ -1,0 +1,146 @@
+// Compile-only smoke test for @enonic-types/lib-graphql.
+// Exercises a realistic schema:
+//   - object type with a typed resolver reading source + args + context
+//   - reference() for self-referential types
+//   - an enum + input object + interface + union
+//   - a Relay-style connection built from graphql-connection
+//   - createSchema() + execute() typed end-to-end
+//   - graphql-rx publish processor + subscriber
+
+import * as graphQlLib from "/lib/graphql";
+import type {
+    DataFetchingEnvironment,
+    ExecutionResult,
+    GraphQLObjectType,
+    GraphQLSchema,
+    SchemaGenerator,
+} from "/lib/graphql";
+import * as graphQlConnectionLib from "/lib/graphql-connection";
+import * as graphQlRxLib from "/lib/graphql-rx";
+
+interface Person {
+    name: string;
+    age: number;
+    children: string[];
+}
+
+interface GetPersonArgs {
+    name: string;
+}
+
+interface AppContext {
+    userId: string;
+}
+
+const schemaGenerator: SchemaGenerator = graphQlLib.newSchemaGenerator();
+
+// Object type with a typed resolver.
+const personType: GraphQLObjectType = schemaGenerator.createObjectType<Person, AppContext>({
+    name: "Person",
+    description: "A person",
+    fields: {
+        name: {
+            type: graphQlLib.nonNull(graphQlLib.GraphQLString),
+            resolve: (env: DataFetchingEnvironment<Person, Record<string, unknown>, AppContext>): string => {
+                return env.source.name;
+            },
+        },
+        age: {
+            type: graphQlLib.nonNull(graphQlLib.GraphQLInt),
+        },
+        children: {
+            type: graphQlLib.list(graphQlLib.reference("Person")),
+            resolve: (env): string[] => env.source.children,
+        },
+    },
+});
+
+// Enum + input + interface + union — ensures each create* returns a distinct branded type.
+const roleEnum = schemaGenerator.createEnumType({
+    name: "Role",
+    values: ["ADMIN", "USER"],
+});
+
+const filterInput = schemaGenerator.createInputObjectType({
+    name: "PersonFilter",
+    fields: {
+        minAge: { type: graphQlLib.GraphQLInt },
+        role: { type: roleEnum },
+    },
+});
+
+const namedInterface = schemaGenerator.createInterfaceType<Person>({
+    name: "Named",
+    fields: {
+        name: { type: graphQlLib.nonNull(graphQlLib.GraphQLString) },
+    },
+    typeResolver: (): GraphQLObjectType => personType,
+});
+
+const nodeUnion = schemaGenerator.createUnionType<Person>({
+    name: "Node",
+    types: [personType, graphQlLib.reference("Person")],
+    typeResolver: (): GraphQLObjectType => personType,
+});
+
+// Suppress "unused" warnings on the branded handles above.
+void namedInterface;
+void nodeUnion;
+
+// Relay connection helper.
+const personConnection: GraphQLObjectType = graphQlConnectionLib.createConnectionType(schemaGenerator, personType);
+
+// getName() is exposed on GraphQLObjectType — used by createConnectionType internally.
+const _connectionName: string = personConnection.getName();
+
+// Root query with typed args + context.
+const queryType = schemaGenerator.createObjectType<undefined, AppContext>({
+    name: "Query",
+    fields: {
+        getPersonByName: {
+            type: personType,
+            args: {
+                name: graphQlLib.nonNull(graphQlLib.GraphQLString),
+                filter: filterInput,
+            },
+            resolve: (env: DataFetchingEnvironment<undefined, GetPersonArgs, AppContext>): Person | null => {
+                void env.context.userId;
+                return { name: env.args.name, age: 0, children: [] };
+            },
+        },
+        persons: {
+            type: personConnection,
+        },
+    },
+});
+
+const schema: GraphQLSchema = schemaGenerator.createSchema({
+    query: queryType,
+    dictionary: [personType],
+});
+
+const result: ExecutionResult<{ getPersonByName: Person | null }> = graphQlLib.execute(
+    schema,
+    "query($name:String!){ getPersonByName(name:$name){ name age } }",
+    { name: "James" },
+    { userId: "42" } satisfies AppContext,
+);
+
+void result.data?.getPersonByName?.age;
+
+// Cursor helpers.
+const cursor: string = graphQlConnectionLib.encodeCursor("42");
+const decoded: string = graphQlConnectionLib.decodeCursor(cursor);
+void decoded;
+
+// Reactive.
+const processor = graphQlRxLib.createPublishProcessor<Person>();
+processor.onNext({ name: "James", age: 42, children: [] });
+processor.onComplete();
+
+const subscriber = graphQlRxLib.createSubscriber<Person>({
+    onNext: (person: Person): void => {
+        void person.name;
+    },
+});
+void subscriber;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "/lib/graphql": ["./index.d.ts"],
+      "/lib/graphql-connection": ["./index.d.ts"],
+      "/lib/graphql-rx": ["./index.d.ts"]
+    },
+    "types": []
+  },
+  "include": [
+    "index.d.ts",
+    "test/*.ts"
+  ]
+}


### PR DESCRIPTION
Adds a published TypeScript types package `@enonic-types/lib-graphql` so consumers no longer hand-maintain declarations for `/lib/graphql`, `/lib/graphql-connection` and `/lib/graphql-rx`. Mirrors the [lib-mustache #66](https://github.com/enonic/lib-mustache/pull/66) scaffolding; the type authoring is the real work here.

## Type model

- **`GraphQLType`** and per-kind subtypes (`GraphQLObjectType`, `GraphQLInputObjectType`, `GraphQLInterfaceType`, `GraphQLUnionType`, `GraphQLEnumType`, `GraphQLScalarType`, `GraphQLTypeReference`) are opaque, nominally-branded handles. Consumers pass them around but do not introspect them. `GraphQLObjectType` exposes `getName()` because `createConnectionType` uses it to derive edge / connection names.
- **Field configs** are typed with `GraphQLFieldConfig<Source, Context>`. The resolver's `env.args` is `any` in the default signature so callers can narrow to a concrete `Args` interface by annotating the resolver's `env` parameter, without an explicit cast:
  ```ts
  resolve: (env: DataFetchingEnvironment<Person, GetPersonArgs, AppContext>): Person | null => {
      return env.args.name.length > 0 ? ... : null;
  }
  ```
  The runtime never validates arg shape (the schema does), so `any` here matches actual behavior — it's a bivariance escape hatch, not blanket looseness.
- **`DataFetchingEnvironment<Source, Args, Context>`** — three generics, all defaulted to `unknown` / `Record<string, unknown>`, reflecting what the Java bridge actually guarantees.
- Extended / custom scalars (`Date`, `DateTime`, `Time`, `Json`, `LocalDateTime`, `LocalTime`) are typed as `GraphQLScalarType` — same shape as the base graphql-java scalars.

Every signature was cross-checked against `GraphQlBean.java`, `DataFetchingEnvironmentMapper.java`, `RxBean.java` (param order, return types), and the `graphql.js` / `graphql-connection.js` / `graphql-rx.js` wrappers.

## Contents

- `types/index.d.ts` — three `declare module` blocks: `/lib/graphql`, `/lib/graphql-connection`, `/lib/graphql-rx`.
- `types/package.json` — `@enonic-types/lib-graphql` manifest, `@enonic-types/core` peer dependency, `publishConfig.access: public`, version `0.0.0` (substituted at build).
- `types/tsconfig.json` + `types/test/typecheck.ts` — build-only smoke test that exercises a realistic schema (object type with a typed resolver reading source, args and context, an enum + input + interface + union, a Relay-style connection built through graphql-connection, and a graphql-rx publish processor / subscriber). Runs under `tsc --noEmit` with strict mode.
- `build.gradle` — `assembleTypes` Copy task -> `build/types/` (version substituted from `project.version`, tsconfig + test excluded from the published artifact); `jar.dependsOn assembleTypes`.
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on build-and-publish + top-level `id-token: write` / `contents: write` permissions for OIDC trusted publishing.

## Verified locally

- `./gradlew build` green.
- `build/types/` contains `index.d.ts` + a `package.json` with `version` substituted to the project version (`3.1.0-SNAPSHOT`).
- `tsc --noEmit -p types/tsconfig.json` passes against the realistic-schema smoke test.

## Follow-up

- `app-guillotine` is the primary consumer — once this publishes, guillotine (and any other apps currently building against untyped `/lib/graphql*`) can depend on `@enonic-types/lib-graphql` instead of local declarations.
- First publish may need npm trusted-publisher setup on the `@enonic-types/lib-graphql` name (release-tools #71 merged).

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)